### PR TITLE
Revert "Bump rack from 2.2.4 to 2.2.6.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.22.1)
     public_suffix (4.0.7)
-    rack (2.2.6.4)
+    rack (2.2.4)
     rack-livereload (0.3.17)
       rack
     rb-fsevent (0.11.1)


### PR DESCRIPTION
Reverts Penhawk/penhawk.com#8